### PR TITLE
fix: the extract-release-notes in extract-release-notes.mjs

### DIFF
--- a/scripts/extract-release-notes.mjs
+++ b/scripts/extract-release-notes.mjs
@@ -1,7 +1,12 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 
 const tag = process.argv[2] || process.env.GITHUB_REF_NAME
-const outputPath = process.argv[3] || 'release-notes.md'
+const outputPath = resolve(process.argv[3] || 'release-notes.md')
+
+if (!outputPath.startsWith(resolve('.'))) {
+  throw new Error('Output path must be within the current working directory')
+}
 
 if (!tag) {
   throw new Error('Usage: node scripts/extract-release-notes.mjs <tag> [output]')


### PR DESCRIPTION
## Summary
Fix high severity security issue in `scripts/extract-release-notes.mjs`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `scripts/extract-release-notes.mjs:4` |
| **Assessment** | Likely exploitable |

**Description**: The extract-release-notes.mjs script accepts an outputPath argument from process.argv[3] without any validation or sanitization. This user-controlled path is passed directly to writeFileSync(), allowing an attacker to write arbitrary content to any location on the filesystem accessible to the Node.js process.

## Evidence

**Exploitation scenario**: Execute: `node scripts/extract-release-notes.mjs v1.0.0 ../../../etc/cron.d/malicious` to write release notes content to /etc/cron.d/malicious.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `scripts/extract-release-notes.mjs`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
